### PR TITLE
fix:typescriptのコンパイルチェックの容量を2048MBから512MBへ

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,11 @@
 module.exports = {
   "transpileDependencies": [
     "vuetify"
-  ]
+  ],
+  chainWebpack: (config) => {
+    config.plugin("fork-ts-checker").tap((args) => {
+      args[0].memoryLimit = 512;
+      return args;
+    });
+  }
 }


### PR DESCRIPTION
メモリの関係でbuild失敗したっぽいので修正